### PR TITLE
Try to Remove Cargo Update From CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,6 @@ jobs:
 
       - name: rustfmt & clippy
         run: |
-          cargo update
           rustup component add clippy rustfmt
           cargo clippy --workspace
           cargo fmt --all -- --check


### PR DESCRIPTION
We want CI to use the versions of the dependencies that have been locked
in our Cargo.lock file.