### PR TITLE
Updates all directional keys to use WASD as defaults

### DIFF
--- a/src/plugins/game/systems/gameplay.rs
+++ b/src/plugins/game/systems/gameplay.rs
@@ -112,19 +112,19 @@ pub fn keyboard_control_input(
         *pause_was_pressed = false;
     }
 
-    if keyboard_input.pressed(KeyCode::Left) {
+    if keyboard_input.pressed(KeyCode::A) {
         control_events.send(ControlEvent::MoveLeft);
     }
 
-    if keyboard_input.pressed(KeyCode::Right) {
+    if keyboard_input.pressed(KeyCode::D) {
         control_events.send(ControlEvent::MoveRight);
     }
 
-    if keyboard_input.pressed(KeyCode::Up) {
+    if keyboard_input.pressed(KeyCode::W) {
         control_events.send(ControlEvent::MoveUp);
     }
 
-    if keyboard_input.pressed(KeyCode::Down) {
+    if keyboard_input.pressed(KeyCode::S) {
         control_events.send(ControlEvent::MoveDown);
     }
 }

--- a/src/plugins/game/systems/gameplay.rs
+++ b/src/plugins/game/systems/gameplay.rs
@@ -112,19 +112,19 @@ pub fn keyboard_control_input(
         *pause_was_pressed = false;
     }
 
-    if keyboard_input.pressed(KeyCode::A) {
+    if keyboard_input.pressed(KeyCode::A) || keyboard_input.pressed(KeyCode::Left) {
         control_events.send(ControlEvent::MoveLeft);
     }
 
-    if keyboard_input.pressed(KeyCode::D) {
+    if keyboard_input.pressed(KeyCode::D) || keyboard_input.pressed(KeyCode::Right) {
         control_events.send(ControlEvent::MoveRight);
     }
 
-    if keyboard_input.pressed(KeyCode::W) {
+    if keyboard_input.pressed(KeyCode::W) || keyboard_input.pressed(KeyCode::Up) {
         control_events.send(ControlEvent::MoveUp);
     }
 
-    if keyboard_input.pressed(KeyCode::S) {
+    if keyboard_input.pressed(KeyCode::S) || keyboard_input.pressed(KeyCode::Down) {
         control_events.send(ControlEvent::MoveDown);
     }
 }


### PR DESCRIPTION
Fixes: https://github.com/katharostech/skipngo/issues/33

We want to default the up, left, down, and right movement keys to the more common WASD until a more extensible configuration solution can be built.

#### Acceptance Criteria:
- [x] When pressing `W` the character moves up 
- [x] When pressing `A` the character moves left
- [x] When pressing `S` the character moves down
- [x] When pressing `D` the character moves right
- [x] When pressing `up arrow` the character moves up 
- [x] When pressing `left arrow` the character moves left
- [x] When pressing `down arrow` the character moves down
- [x] When pressing `right arrow` the character moves right


#### VALIDATION
1. Checkout this branch: `change-directional-keys`
2. cargo run -- --asset-dir [LOCATION of your assets with an in gamer character that uses movement]
3. Verify that `W`, `A`, `S`, `D` moves the character as expected


#### NOTES

* We had some discussion around some configuration approaches that would work well but those will be a future concern.
* Additionally I was thinking that we'd make this change to encapsulate `up arrow` || `W` but that just seemed to introduce unnecessary complexity that was going to be replaced by a future config feature.
* This may need to be reconsidered for modified keyboard layouts and non-US layouts - though that can easily be an AC of the configuration work.